### PR TITLE
fix: pass & parse shutdown options

### DIFF
--- a/src/microservicekit.js
+++ b/src/microservicekit.js
@@ -19,8 +19,8 @@ class MicroserviceKit {
 
 
   init() {
-    if (!this.options_.amqp) { return Promise.resolve(); }
     this.shutdownKit.setoptions(this.options_.shutdown);
+    if (!this.options_.amqp) { return Promise.resolve(); }
     const amqpOptions = _.assign({}, this.options_.amqp, { id: this.getName() });
     this.amqpKit = new AmqpKit(amqpOptions);
     return this.amqpKit.init();

--- a/src/shutdownkit.js
+++ b/src/shutdownkit.js
@@ -21,7 +21,9 @@ class ShutdownKit {
    * @param opt_options
    */
   setoptions(opt_options) {
-    this.options_ = Object.assign({}, this.defaultOptions_, _.pick(this.defaultOptions_, opt_options));
+    const defaultKeys = _.keys(this.defaultOptions_);
+    const filteredOptions = _.pick(opt_options, defaultKeys)
+    this.options_ = Object.assign({}, this.defaultOptions_, filteredOptions);
   }
 
   /**


### PR DESCRIPTION
- shutdown options is not passed down if amqp is disabled
- shutdown options are not picked and only default values are used